### PR TITLE
Fix cache incorrectly checking td_meta_type against DECORATION

### DIFF
--- a/src/BetterTerrainPP.cpp
+++ b/src/BetterTerrainPP.cpp
@@ -273,7 +273,7 @@ bool BetterTerrainPP::init(godot::TileMap* map)
           peering[int(key)] = std::move(targets);
         }
 
-        if (td_meta_type == TerrainType::DECORATION && peering.empty())
+        if (td_meta_type == TerrainType::EMPTY && peering.empty())
           continue;
 
         int symmetry = td_meta.get("symmetry", SymmetryType::NONE);


### PR DESCRIPTION
Fixes #3

I reviewed the cache loading code for the GDExtension against the GDScript implementation, and the part on checking the td_meta_type stood out:

GDExtension:
```c++
if (td_meta_type == TerrainType::DECORATION && peering.empty())
    continue;
```

GDScript:
```gdscript
# Decoration tiles without peering are skipped
if td_meta.type == TileCategory.EMPTY and !peering:
    continue
```

Since td_meta_type returns the tile category type, it makes no sense to check again `TerrainType::DECORATION`. Since `DECORATION = 3`, any terrain with id 3 will match against this if statement and be prevented from adding a placement to their terrain cache. After correcting it to `TerrainType::EMPTY`, everything works. 

As an aside, I don't know why `TileCategory` and `TerrainType` aren't separated in the GDExtension version and instead lumped together under `TerrainType`. Could this be for efficiency?