### PR TITLE
Update godot-cpp to fix memory leak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .sconsign.dblite
 bin/
 *.os
+*.json
+*.obj


### PR DESCRIPTION
Closes #6 

Older versions of godot-cpp had a memory leak when accessing fields from a Dictionary. This PR updates godot-cpp to the latest 4.2 version, which fixes this leak.

See this comment on godot-cpp for more details: https://github.com/godotengine/godot-cpp/issues/1240#issuecomment-2094294097